### PR TITLE
Adjust render order of rectangle shapes

### DIFF
--- a/src/components/scene/builders/rectangle.js
+++ b/src/components/scene/builders/rectangle.js
@@ -213,7 +213,7 @@ class Rectangle {
     }
 
     get renderOrder() {
-        return 0;
+        return 0.5;
     }
 
     get mesh() {

--- a/src/components/scene/builders/texture_rectangle.js
+++ b/src/components/scene/builders/texture_rectangle.js
@@ -119,6 +119,10 @@ class TextureRectangle extends Rectangle {
     get builderType() {
         return 'TextureRectangle';
     }
+
+    get renderOrder() {
+        return 0;
+    }
 }
 
 export default TextureRectangle;


### PR DESCRIPTION
Lower render order of texture rectangle so that it's always in the background.